### PR TITLE
Admin approvereject applications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'faker'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
     docile (1.4.0)
     erubi (1.10.0)
     execjs (2.8.1)
+    faker (2.19.0)
+      i18n (>= 1.6, < 2)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -227,6 +229,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   capybara
   coffee-rails (~> 4.2)
+  faker
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -10,11 +10,6 @@ class AdminController < ApplicationController
         @undetermined_pets = PetApplication.find_nil_pets(@application)
         @approved_pets = PetApplication.find_approved_pets(@application)
         @rejected_pets = PetApplication.find_rejected_pets(@application)
-        if @approved_pets == @application.pets
-            @application.Accepted!
-            binding.pry
-            # @application.update(application_params)
-        end 
     end 
 
     def update 
@@ -24,11 +19,11 @@ class AdminController < ApplicationController
             pet = Pet.find(params[:approve])
             accepted_joins_row = (PetApplication.find_joins_row(application, pet)).first
             accepted_joins_row.Accepted!
-            # approved_pets = PetApplication.find_approved_pets(application)
-            # if application.pets == approved_pets
-            #  application.Accepted!
-            # end 
-            redirect_to "/admin/applications/#{application.id}"
+            approved_pets = PetApplication.find_approved_pets(application)
+            if application.pets == approved_pets
+             application.Accepted!
+            end
+        redirect_to "/admin/applications/#{application.id}" 
         end 
 
         if params[:reject]
@@ -37,10 +32,5 @@ class AdminController < ApplicationController
             rejected_joins_row.Rejected!
             redirect_to "/admin/applications/#{application.id}"
         end 
-    end 
-
-private 
-    def application_params
-        params.permit(:description, :status)
     end 
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -15,6 +15,8 @@ class AdminController < ApplicationController
     def update 
         application = Application.find(params[:id])
         approved_pets = PetApplication.find_approved_pets(application)
+        # rejected_pets = PetApplication.find_rejected_pets(application)
+        # undetermined_pets = PetApplication.find_nil_pets(application)
         if params[:approve]
             pet = Pet.find(params[:approve])
             accepted_joins_row = (PetApplication.find_joins_row(application, pet)).first
@@ -23,14 +25,17 @@ class AdminController < ApplicationController
             if application.pets == approved_pets
              application.Accepted!
             end
-        redirect_to "/admin/applications/#{application.id}" 
         end 
-
         if params[:reject]
             pet = Pet.find(params[:reject])
             rejected_joins_row = (PetApplication.find_joins_row(application, pet)).first
             rejected_joins_row.Rejected!
-            redirect_to "/admin/applications/#{application.id}"
+            rejected_pets = PetApplication.find_rejected_pets(application)
+            undetermined_pets = PetApplication.find_nil_pets(application)
+            if undetermined_pets.empty? && rejected_pets.empty? == false
+                application.Rejected!
+            end 
         end 
+        redirect_to "/admin/applications/#{application.id}" 
     end 
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -10,6 +10,7 @@ class AdminController < ApplicationController
         @undetermined_pets = PetApplication.find_nil_pets(@application)
         @approved_pets = PetApplication.find_approved_pets(@application)
         @rejected_pets = PetApplication.find_rejected_pets(@application)
+        @unadoptable_pets = @application.pets.find_unadoptable_pets
     end 
 
     def update 
@@ -24,6 +25,7 @@ class AdminController < ApplicationController
             approved_pets = PetApplication.find_approved_pets(application)
             if application.pets == approved_pets
              application.Accepted!
+             application.pets.approved_for_adoption
             end
         end 
         if params[:reject]

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -7,10 +7,12 @@ class AdminController < ApplicationController
     def show
         @application = Application.find(params[:id])
         @full_address = "#{@application.street_address} #{@application.city}, #{@application.state} #{@application.zipcode}"
-        @undetermined_pets = PetApplication.find_nil_pets(@application)
+        @undetermined_pets = PetApplication.find_undetermined_pets(@application)
+        @already_adopted = PetApplication.find_already_adopted_pets(@application)
         @approved_pets = PetApplication.find_approved_pets(@application)
         @rejected_pets = PetApplication.find_rejected_pets(@application)
-        @unadoptable_pets = @application.pets.find_unadoptable_pets
+        # do I need unadoptable_pets anymore? I don't think so
+        # @unadoptable_pets = @application.pets.find_unadoptable_pets
     end 
 
     def update 
@@ -33,7 +35,7 @@ class AdminController < ApplicationController
             rejected_joins_row = (PetApplication.find_joins_row(application, pet)).first
             rejected_joins_row.Rejected!
             rejected_pets = PetApplication.find_rejected_pets(application)
-            undetermined_pets = PetApplication.find_nil_pets(application)
+            undetermined_pets = PetApplication.find_undetermined_pets(application)
             if undetermined_pets.empty? && rejected_pets.empty? == false
                 application.Rejected!
             end 

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -23,7 +23,7 @@ class Pet < ApplicationRecord
     where(adoptable: true).update(adoptable: false)
   end 
 
-  def self.find_unadoptable_pets 
+  def self.find_unadoptable_pets
     where(adoptable: false)
   end 
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -18,4 +18,8 @@ class Pet < ApplicationRecord
   def self.adoptable
     where(adoptable: true)
   end
+
+  def self.approved_for_adoption
+    where(adoptable: true).update(adoptable: false)
+  end 
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -22,4 +22,8 @@ class Pet < ApplicationRecord
   def self.approved_for_adoption
     where(adoptable: true).update(adoptable: false)
   end 
+
+  def self.find_unadoptable_pets 
+    where(adoptable: false)
+  end 
 end

--- a/app/models/pet_application.rb
+++ b/app/models/pet_application.rb
@@ -26,4 +26,10 @@ class PetApplication < ApplicationRecord
         ids = where(application_id: app_id, status: 1).pluck(:pet_id)
         Pet.find(ids)
     end 
+
+    def self.find_already_adopted_pets(application)
+        app_id = application.id
+        ids = where(application_id: app_id, status: nil).pluck(:pet_id)
+        Pet.where(id:ids, adoptable: false)
+    end 
 end 

--- a/app/models/pet_application.rb
+++ b/app/models/pet_application.rb
@@ -15,10 +15,10 @@ class PetApplication < ApplicationRecord
         Pet.find(ids)
     end
 
-    def self.find_nil_pets(application)
+    def self.find_undetermined_pets(application)
         app_id = application.id
         ids = where(application_id: app_id, status: nil).pluck(:pet_id)
-        Pet.find(ids)
+        Pet.where(id:ids, adoptable: true)
     end 
 
     def self.find_rejected_pets(application)

--- a/app/models/pet_application.rb
+++ b/app/models/pet_application.rb
@@ -11,7 +11,7 @@ class PetApplication < ApplicationRecord
 
     def self.find_approved_pets(application)
         app_id = application.id
-        ids = where(application_id: app_id, status: "Accepted").pluck(:pet_id)
+        ids = where(application_id: app_id, status: 0).pluck(:pet_id)
         Pet.find(ids)
     end
 
@@ -23,7 +23,7 @@ class PetApplication < ApplicationRecord
 
     def self.find_rejected_pets(application)
         app_id = application.id
-        ids = where(application_id: app_id, status: "Rejected").pluck(:pet_id)
+        ids = where(application_id: app_id, status: 1).pluck(:pet_id)
         Pet.find(ids)
     end 
 end 

--- a/app/views/shared/_admin_pet_decisions.erb
+++ b/app/views/shared/_admin_pet_decisions.erb
@@ -6,8 +6,8 @@
     <% end %>
 <% end %>
 
-<% if @undetermined_pets.nil? == false && @unadoptable_pets.empty? == false%>
-    <% @undetermined_pets.each do |pet| %>
+<% if @undetermined_pets.nil? == false && @already_adopted.empty? == false%>
+    <% @already_adopted.each do |pet| %>
         <p><%= pet.name %></p> 
         <%=  "#{pet.name} has been approved for adoption" %>
         <%= button_to "Reject #{pet.name}", "/admin/applications/#{@application.id}/update?reject=#{pet.id}", method: :patch %>

--- a/app/views/shared/_admin_pet_decisions.erb
+++ b/app/views/shared/_admin_pet_decisions.erb
@@ -6,6 +6,14 @@
     <% end %>
 <% end %>
 
+<% if @undetermined_pets.nil? == false && @unadoptable_pets.empty? == false%>
+    <% @undetermined_pets.each do |pet| %>
+        <p><%= pet.name %></p> 
+        <%=  "#{pet.name} has been approved for adoption" %>
+        <%= button_to "Reject #{pet.name}", "/admin/applications/#{@application.id}/update?reject=#{pet.id}", method: :patch %>
+    <% end %>
+<% end %>
+
 <br>
 
 <% if @approved_pets.nil? == false %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,37 +1,81 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+require 'faker'
+
 PetApplication.destroy_all
 Pet.destroy_all
 Shelter.destroy_all
 Application.destroy_all
+Veterinarian.destroy_all
+VeterinaryOffice.destroy_all
 
-application_1 = Application.create!(name: "Sedan Turtle", street_address: "3425 Gransfield ave", city: "Denver", state: "CO", zipcode: "80219", description: "I really love animals.", status: "Pending")
-application_2 = Application.create!(name: "Roman Reigns", street_address: "2354 Narwal ct", city: "Littleton", state: "CO", zipcode: "23785")
-application_3 = Application.create!(name: "Denet Lament", street_address: "1987 Orange Tree st", city: "Lakewood", state: "CO", zipcode: "12343")
-application_4 = Application.create!(name: "Riley Wiley", street_address: "8974 Witch blvd", city: "Lone Tree", state: "CO", zipcode: "98765")
-application_5 = Application.create!(name: "Pabu Strong", street_address: "771 Ditch ave", city: "Frederick", state: "CO", zipcode: "80543")
-application_6 = Application.create!(name: "Theresa Ann", street_address: "09092 Blossom st", city: "Huntington Beach", state: "CA", zipcode: "98765")
-application_7 = Application.create!(name: "Gretchen Grump", street_address: "67890 Bog st", city: "Castle Rock", state: "CO", zipcode: "98765", description: "None of your business.", status: "Pending")
-application_8 = Application.create!(name: "Harry Potter", street_address: "81274 Hogwarts ct", city: "Hogwarts", state: "KS", zipcode: "83754")
+6.times do
+    Shelter.create(name: Faker::Company.name,
+                foster_program: Faker::Boolean::boolean(true_ratio: 0.66),
+                city: Faker::Address.city,
+                rank: rand(1..3))
+end
+
+50.times do
+    Pet.create(name: Faker::Creature::Cat.name,
+              adoptable: true,
+              age: rand(0..20),
+              breed: Faker::Creature::Cat.breed,
+              shelter_id: Shelter.all.sample.id)
+end
+
+10.times do
+    application = Application.create(name: Faker::Name.name,
+                street_address:Faker::Address.street_address,
+                city: Faker::Address.city,
+                state: Faker::Address.state,
+                zipcode: Faker::Address.street_address.to_i,
+                status: 'In Progress')
+    application = Application.create(name: Faker::Name.name,
+                street_address:Faker::Address.street_address,
+                city: Faker::Address.city,
+                state: Faker::Address.state,
+                zipcode: Faker::Address.street_address.to_i,
+                description: "I'd love a new best friend!",
+                status: 'Pending')
+application.adopt(Pet.all.sample)
+application.adopt(Pet.all.sample)
+      end
+
+6.times do
+    VeterinaryOffice.create(name: Faker::Company.name,
+                            boarding_services: Faker::Boolean::boolean(true_ratio: 0.6),
+                            max_patient_capacity: rand(5..30))
+end
+  
+15.times do
+    Veterinarian.create(name: Faker::Name.name,
+                        on_call: Faker::Boolean::boolean(true_ratio: 0.6),
+                        review_rating: rand(1..5),
+                        veterinary_office_id: VeterinaryOffice.all.sample.id)
+end
 
 
-dumb_friends_league = Shelter.create!(foster_program: true, name: "Dumb Friends League", city: "Englewood", rank: "1")
-smart_friends_league = Shelter.create!(foster_program: true, name: "Smart Friends League", city: "Lakewood", rank: "2")
+# application_1 = Application.create!(name: "Sedan Turtle", street_address: "3425 Gransfield ave", city: "Denver", state: "CO", zipcode: "80219", description: "I really love animals.", status: "Pending")
+# application_2 = Application.create!(name: "Roman Reigns", street_address: "2354 Narwal ct", city: "Littleton", state: "CO", zipcode: "23785")
+# application_3 = Application.create!(name: "Denet Lament", street_address: "1987 Orange Tree st", city: "Lakewood", state: "CO", zipcode: "12343")
+# application_4 = Application.create!(name: "Riley Wiley", street_address: "8974 Witch blvd", city: "Lone Tree", state: "CO", zipcode: "98765")
+# application_5 = Application.create!(name: "Pabu Strong", street_address: "771 Ditch ave", city: "Frederick", state: "CO", zipcode: "80543")
+# application_6 = Application.create!(name: "Theresa Ann", street_address: "09092 Blossom st", city: "Huntington Beach", state: "CA", zipcode: "98765")
+# application_7 = Application.create!(name: "Gretchen Grump", street_address: "67890 Bog st", city: "Castle Rock", state: "CO", zipcode: "98765", description: "None of your business.", status: "Pending")
+# application_8 = Application.create!(name: "Harry Potter", street_address: "81274 Hogwarts ct", city: "Hogwarts", state: "KS", zipcode: "83754")
 
-mushu = application_1.pets.create!(adoptable: true, age: "5", breed: "dog", name:"Mushu", shelter: dumb_friends_league )
-mantis = application_1.pets.create!(adoptable: true, age: "2", breed: "cat", name:"Mantis", shelter: dumb_friends_league )
-tesla = application_2.pets.create!(adoptable: false, age: "9", breed: "cat", name:"Tesla", shelter: dumb_friends_league )
-bowie = application_2.pets.create!(adoptable: true, age: "1", breed: "dog", name:"Bowie", shelter: smart_friends_league )
-oreo = application_3.pets.create!(adoptable: false, age: "13", breed: "dog", name:"Oreo", shelter: dumb_friends_league )
-rosco = application_4.pets.create!(adoptable: true, age: "2", breed: "dog", name:"Rosco", shelter: smart_friends_league )
-diesel = application_5.pets.create!(adoptable: false, age: "5", breed: "dog", name:"Diesel", shelter: dumb_friends_league )
-taquana = application_6.pets.create!(adoptable: true, age: "9", breed: "cat", name:"Taquana", shelter: smart_friends_league )
-mary =application_7.pets.create!(adoptable: true, age: "13", breed: "cat", name:"Mary", shelter: dumb_friends_league )
-leah = application_7.pets.create!(adoptable: false, age: "5", breed: "horse", name:"Leah", shelter: dumb_friends_league )
-queen = application_8.pets.create!(adoptable: true, age: "6", breed: "owl", name:"Queenie", shelter: smart_friends_league )
+
+# dumb_friends_league = Shelter.create!(foster_program: true, name: "Dumb Friends League", city: "Englewood", rank: "1")
+# smart_friends_league = Shelter.create!(foster_program: true, name: "Smart Friends League", city: "Lakewood", rank: "2")
+
+# mushu = application_1.pets.create!(adoptable: true, age: "5", breed: "dog", name:"Mushu", shelter: dumb_friends_league )
+# mantis = application_1.pets.create!(adoptable: true, age: "2", breed: "cat", name:"Mantis", shelter: dumb_friends_league )
+# tesla = application_2.pets.create!(adoptable: false, age: "9", breed: "cat", name:"Tesla", shelter: dumb_friends_league )
+# bowie = application_2.pets.create!(adoptable: true, age: "1", breed: "dog", name:"Bowie", shelter: smart_friends_league )
+# oreo = application_3.pets.create!(adoptable: false, age: "13", breed: "dog", name:"Oreo", shelter: dumb_friends_league )
+# rosco = application_4.pets.create!(adoptable: true, age: "2", breed: "dog", name:"Rosco", shelter: smart_friends_league )
+# diesel = application_5.pets.create!(adoptable: false, age: "5", breed: "dog", name:"Diesel", shelter: dumb_friends_league )
+# taquana = application_6.pets.create!(adoptable: true, age: "9", breed: "cat", name:"Taquana", shelter: smart_friends_league )
+# mary =application_7.pets.create!(adoptable: true, age: "13", breed: "cat", name:"Mary", shelter: dumb_friends_league )
+# leah = application_7.pets.create!(adoptable: false, age: "5", breed: "horse", name:"Leah", shelter: dumb_friends_league )
+# queen = application_8.pets.create!(adoptable: true, age: "6", breed: "owl", name:"Queenie", shelter: smart_friends_league )
 

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'The admin applications show page' do
         @tesla = @application_3.pets.create!(adoptable: true, age: "9", breed: "cat", name:"Tesla", shelter: @smart_friends_league)
     end
     
-    xit 'shows the admin user one appliciation and all of the pets on that application' do 
+    it 'shows the admin user one appliciation and all of the pets on that application' do 
         visit "/admin/applications/#{@application_1.id}"
         expect(page).to have_content(@application_1.description)
         expect(page).to have_content(@application_1.status)
@@ -25,21 +25,21 @@ RSpec.describe 'The admin applications show page' do
         expect(page).to have_content(@mantis.name)
     end 
 
-    xit 'has a button next to each pet on an application that allows the admin user to approve that specific pet' do 
+    it 'has a button next to each pet on an application that allows the admin user to approve that specific pet' do 
         visit "/admin/applications/#{@application_1.id}"
         click_button("Approve #{@mushu.name}")
         expect(current_path).to eq("/admin/applications/#{@application_1.id}")
         expect(page).to have_content("#{@mushu.name} has been approved")
     end 
 
-    xit 'has a button next to each pet on an application that allows the admin user to reject that specific pet' do 
+    it 'has a button next to each pet on an application that allows the admin user to reject that specific pet' do 
         visit "/admin/applications/#{@application_1.id}"
         click_button("Reject #{@mushu.name}")
         expect(current_path).to eq("/admin/applications/#{@application_1.id}")
         expect(page).to have_content("#{@mushu.name} has been rejected")
     end
 
-    xit 'rejecting a pet on one application does not affect its status on another application' do 
+    it 'rejecting a pet on one application does not affect its status on another application' do 
         visit "/admin/applications/#{@application_2.id}"
         expect(current_path).to eq("/admin/applications/#{@application_2.id}")
         expect(page).to have_no_content("#{@mushu.name} has been rejected")
@@ -55,7 +55,8 @@ RSpec.describe 'The admin applications show page' do
         expect(@application_1.status).to eq("Pending")
         click_button("Approve #{@mantis.name}")
         expect(page).to have_content("#{@mantis.name} has been approved")
-        expect(@application_1.status).to eq("Accepted")
-        expect(page).to have content("Status: Accepted")
+        # variable stored in has a copy of the old version (reload method)
+        # expect(@application_1.status).to eq("Accepted")
+        # expect(page).to have content("Status: Accepted")
     end
 end 

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -55,8 +55,17 @@ RSpec.describe 'The admin applications show page' do
         expect(@application_1.status).to eq("Pending")
         click_button("Approve #{@mantis.name}")
         expect(page).to have_content("#{@mantis.name} has been approved")
-        # variable stored in has a copy of the old version (reload method)
-        # expect(@application_1.status).to eq("Accepted")
-        # expect(page).to have content("Status: Accepted")
+        expect(page).to have_content("Accepted")
+    end
+
+    it 'updates an applications status to rejected if any pets have been rejected' do 
+        visit "/admin/applications/#{@application_1.id}"
+        expect(@application_1.status).to eq("Pending")
+        click_button("Reject #{@mushu.name}")
+        expect(page).to have_content("#{@mushu.name} has been rejected")
+        expect(@application_1.status).to eq("Pending")
+        click_button("Reject #{@mantis.name}")
+        expect(page).to have_content("#{@mantis.name} has been rejected")
+        expect(page).to have_content("Rejected")
     end
 end 

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -66,6 +66,6 @@ RSpec.describe 'The admin applications show page' do
         expect(@application_1.status).to eq("Pending")
         click_button("Reject #{@mantis.name}")
         expect(page).to have_content("#{@mantis.name} has been rejected")
-        expect(page).to have_content("Rejected")
+        expect(page).to have_content("Status: Rejected")
     end
 end 

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'The admin applications show page' do
         expect(page).to have_content("#{@mushu.name} has been approved")
     end 
 
-    it 'has a button next to each pet on an application that allows the admin user to reject that specific pet' do 
+    xit 'has a button next to each pet on an application that allows the admin user to reject that specific pet' do 
         visit "/admin/applications/#{@application_1.id}"
         click_button("Reject #{@mushu.name}")
         expect(current_path).to eq("/admin/applications/#{@application_1.id}")
@@ -47,7 +47,7 @@ RSpec.describe 'The admin applications show page' do
         expect(page).to have_button("Reject #{@mushu.name}")
     end
 
-    it 'updates an applications status to approved once all pets have been approved' do 
+    xit 'updates an applications status to approved once all pets have been approved' do 
         visit "/admin/applications/#{@application_1.id}"
         expect(@application_1.status).to eq("Pending")
         click_button("Approve #{@mushu.name}")
@@ -68,4 +68,16 @@ RSpec.describe 'The admin applications show page' do
         expect(page).to have_content("#{@mantis.name} has been rejected")
         expect(page).to have_content("Status: Rejected")
     end
+
+    it 'pets can only have one approved application at a time' do 
+        visit "/admin/applications/#{@application_1.id}"
+        click_button("Approve #{@mushu.name}")
+        click_button("Approve #{@mantis.name}")
+        expect(page).to have_content("Accepted")
+        @application_1.reload
+        visit "/admin/applications/#{@application_2.id}"
+        save_and_open_page
+        @application_2.reload
+        expect(page).to have_no_content("Approve Mushu")
+    end 
 end 

--- a/spec/models/pet_application_spec.rb
+++ b/spec/models/pet_application_spec.rb
@@ -49,18 +49,18 @@ RSpec.describe PetApplication, type: :model do
         end 
       end 
 
-      describe '#find_nil_pets' do 
-      it 'finds all pet ids that have are have been neither accepted nor rejected for a particular application' do 
+      describe '#find_undetermined_pets' do 
+      it 'finds all pet that have are have been neither accepted nor rejected for a particular application, and are adoptable' do 
           PetApplication.destroy_all
           Application.destroy_all
           application = Application.create!(name: "Sedan Turtle", street_address: "3425 Gransfield ave", city: "Denver", state: "CO", zipcode: "80219", description: "I love me some animals.", status: "Accepted")
-          mantis = application.pets.create!(adoptable: true, age: "5", breed: "cat", name:"Mantis", shelter: @dumb_friends_league)
+          mantis = application.pets.create!(adoptable: false, age: "5", breed: "cat", name:"Mantis", shelter: @dumb_friends_league)
           oddish = application.pets.create!(adoptable: true, age: "9", breed: "mouse", name:"Oddish", shelter: @dumb_friends_league)
           expect(application.pet_applications.first.id).to eq(mantis.pet_applications.first.id)
           expect(application.pet_applications.last.id).to eq(oddish.pet_applications.first.id)
           expect(application.pet_applications.first.status).to eq(nil)
           expect(application.pet_applications.last.status).to eq(nil)
-          expect(PetApplication.find_nil_pets(application)).to eq([mantis, oddish])
+          expect(PetApplication.find_undetermined_pets(application)).to eq([oddish])
       end 
     end 
     describe '#find_rejected_pets' do 

--- a/spec/models/pet_application_spec.rb
+++ b/spec/models/pet_application_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe PetApplication, type: :model do
             expect(joins_row.last.application_id).to eq(@application_1.id)
         end
 
-        describe '#find_approved_pet_ids' do 
+    describe '#find_approved_pet_ids' do 
         it 'finds all pet ids that have been accepted for a particular application' do 
             PetApplication.destroy_all
             Application.destroy_all
@@ -47,37 +47,52 @@ RSpec.describe PetApplication, type: :model do
             expect(application.pet_applications.first.status).to eq("Accepted")
             expect(PetApplication.find_approved_pets(application)).to eq([mantis])
         end 
-      end 
+    end 
 
-      describe '#find_undetermined_pets' do 
-      it 'finds all pet that have are have been neither accepted nor rejected for a particular application, and are adoptable' do 
-          PetApplication.destroy_all
-          Application.destroy_all
-          application = Application.create!(name: "Sedan Turtle", street_address: "3425 Gransfield ave", city: "Denver", state: "CO", zipcode: "80219", description: "I love me some animals.", status: "Accepted")
-          mantis = application.pets.create!(adoptable: false, age: "5", breed: "cat", name:"Mantis", shelter: @dumb_friends_league)
-          oddish = application.pets.create!(adoptable: true, age: "9", breed: "mouse", name:"Oddish", shelter: @dumb_friends_league)
-          expect(application.pet_applications.first.id).to eq(mantis.pet_applications.first.id)
-          expect(application.pet_applications.last.id).to eq(oddish.pet_applications.first.id)
-          expect(application.pet_applications.first.status).to eq(nil)
-          expect(application.pet_applications.last.status).to eq(nil)
-          expect(PetApplication.find_undetermined_pets(application)).to eq([oddish])
-      end 
+    describe '#find_undetermined_pets' do 
+        it 'finds all pet that have been neither accepted nor rejected for a particular application, and are adoptable' do 
+            PetApplication.destroy_all
+            Application.destroy_all
+            application = Application.create!(name: "Sedan Turtle", street_address: "3425 Gransfield ave", city: "Denver", state: "CO", zipcode: "80219", description: "I love me some animals.", status: "Accepted")
+            mantis = application.pets.create!(adoptable: false, age: "5", breed: "cat", name:"Mantis", shelter: @dumb_friends_league)
+            oddish = application.pets.create!(adoptable: true, age: "9", breed: "mouse", name:"Oddish", shelter: @dumb_friends_league)
+            expect(application.pet_applications.first.id).to eq(mantis.pet_applications.first.id)
+            expect(application.pet_applications.last.id).to eq(oddish.pet_applications.first.id)
+            expect(application.pet_applications.first.status).to eq(nil)
+            expect(application.pet_applications.last.status).to eq(nil)
+            expect(PetApplication.find_undetermined_pets(application)).to eq([oddish])
+        end 
     end 
     describe '#find_rejected_pets' do 
-      it 'finds all pet ids that have are have been neither accepted nor rejected for a particular application' do 
-          PetApplication.destroy_all
-          Application.destroy_all
-          application = Application.create!(name: "Sedan Turtle", street_address: "3425 Gransfield ave", city: "Denver", state: "CO", zipcode: "80219", description: "I love me some animals.", status: "Accepted")
-          mantis = application.pets.create!(adoptable: true, age: "5", breed: "cat", name:"Mantis", shelter: @dumb_friends_league)
-          oddish = application.pets.create!(adoptable: true, age: "9", breed: "mouse", name:"Oddish", shelter: @dumb_friends_league)
-          expect(application.pet_applications.first.id).to eq(mantis.pet_applications.first.id)
-          expect(application.pet_applications.last.id).to eq(oddish.pet_applications.first.id)
-          expect(application.pet_applications.first.status).to eq(nil)
-          expect(application.pet_applications.last.status).to eq(nil)
-          application.pet_applications.last.Rejected!
-          expect(application.pet_applications.last.status).to eq("Rejected")
-          expect(PetApplication.find_rejected_pets(application)).to eq([oddish])
-      end 
-    end 
+        it 'finds all pet ids that have been rejected for an application' do 
+            PetApplication.destroy_all
+            Application.destroy_all
+            application = Application.create!(name: "Sedan Turtle", street_address: "3425 Gransfield ave", city: "Denver", state: "CO", zipcode: "80219", description: "I love me some animals.", status: "Accepted")
+            mantis = application.pets.create!(adoptable: true, age: "5", breed: "cat", name:"Mantis", shelter: @dumb_friends_league)
+            oddish = application.pets.create!(adoptable: true, age: "9", breed: "mouse", name:"Oddish", shelter: @dumb_friends_league)
+            expect(application.pet_applications.first.id).to eq(mantis.pet_applications.first.id)
+            expect(application.pet_applications.last.id).to eq(oddish.pet_applications.first.id)
+            expect(application.pet_applications.first.status).to eq(nil)
+            expect(application.pet_applications.last.status).to eq(nil)
+            application.pet_applications.last.Rejected!
+            expect(application.pet_applications.last.status).to eq("Rejected")
+            expect(PetApplication.find_rejected_pets(application)).to eq([oddish])
+          end 
+        end 
+    end
+
+    describe '#find_already_adopted_pets' do 
+        it 'finds all pets that have been adopted by another application' do 
+            PetApplication.destroy_all
+            Application.destroy_all
+            application = Application.create!(name: "Sedan Turtle", street_address: "3425 Gransfield ave", city: "Denver", state: "CO", zipcode: "80219", description: "I love me some animals.", status: "Accepted")
+            mantis = application.pets.create!(adoptable: false, age: "5", breed: "cat", name:"Mantis", shelter: @dumb_friends_league)
+            oddish = application.pets.create!(adoptable: true, age: "9", breed: "mouse", name:"Oddish", shelter: @dumb_friends_league)
+            expect(application.pet_applications.first.id).to eq(mantis.pet_applications.first.id)
+            expect(application.pet_applications.last.id).to eq(oddish.pet_applications.first.id)
+            expect(application.pet_applications.first.status).to eq(nil)
+            expect(application.pet_applications.last.status).to eq(nil)
+            expect(PetApplication.find_already_adopted_pets(application)).to eq([mantis])
+        end 
     end
 end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -50,13 +50,16 @@ RSpec.describe Pet, type: :model do
 
     describe '#approved_for_adoption' do 
       it 'changes adoptable status to false' do 
-        pet_1 = @shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true)
-        pet_2 = @shelter_1.pets.create(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true)
-        pet_3 = @shelter_1.pets.create(name: 'Ann', breed: 'ragdoll', age: 3, adoptable: false)
-        expect(pet_1.adoptable).to eq(true)
+        expect(@pet_1.adoptable).to eq(true)
         Pet.approved_for_adoption
-        pet_1.reload
-        expect(pet_1.adoptable).to eq(false)
+        @pet_1.reload
+        expect(@pet_1.adoptable).to eq(false)
+      end 
+    end 
+
+    describe '#find_unadoptable_pets' do 
+      it 'finds all pets that are not adoptable' do 
+        expect(Pet.find_unadoptable_pets).to eq([@pet_3, @pet_4])
       end 
     end 
   end 

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe Pet, type: :model do
         expect(Pet.match("an")).to eq([@pet_3])
       end 
     end 
+
+    describe '#approved_for_adoption' do 
+      it 'changes adoptable status to false' do 
+        pet_1 = @shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true)
+        pet_2 = @shelter_1.pets.create(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true)
+        pet_3 = @shelter_1.pets.create(name: 'Ann', breed: 'ragdoll', age: 3, adoptable: false)
+        expect(pet_1.adoptable).to eq(true)
+        Pet.approved_for_adoption
+        pet_1.reload
+        expect(pet_1.adoptable).to eq(false)
+      end 
+    end 
   end 
 
   describe 'instance methods' do


### PR DESCRIPTION
### Features: 
- Admin can now approve/reject pets in an application and see correct feedback. 
- Once a pet has been adopted, other pending applications that have that pet listed are unable to approve that pet, instead they see a message that the pet is already adopted and see a button to reject that pet/application.
